### PR TITLE
This is apparently the better way to log

### DIFF
--- a/local.py
+++ b/local.py
@@ -11,7 +11,7 @@ logger.setLevel(logging.WARNING)
 # Create a console logger
 ch = logging.StreamHandler()
 ch.setLevel(logging.DEBUG)
-ch.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+ch.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
 logger.addHandler(ch)
 
 

--- a/run_server.py
+++ b/run_server.py
@@ -9,13 +9,13 @@ logger.setLevel(logging.DEBUG)
 # Create a console logger
 ch = logging.StreamHandler()
 ch.setLevel(logging.WARNING)
-ch.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+ch.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
 logger.addHandler(ch)
 
 # Create a file logger with everything
 fh = logging.FileHandler("server.log", mode="a", encoding="utf-8")
 fh.setLevel(logging.DEBUG)
-fh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+fh.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
 logger.addHandler(fh)
 
 

--- a/server/game.py
+++ b/server/game.py
@@ -1,8 +1,10 @@
-from server import logger
 from server.scenes import *
 from server.response import Response, LastMessage, MessageResponse, OptionResponse
 from server.agents.conversation import LLM_t, PlayerAgent, Agent
 import yaml
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Session:

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,8 +1,12 @@
 import uuid
 from flask import Flask, request, jsonify
 from server.game import play_game, initialize_game  
-from server import game_states, app, logger
+from server import game_states, app
 from server.response import marshal_response
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 @app.route('/start', methods=['GET'])
 def start_game():


### PR DESCRIPTION
Every file should get its own `getLogger(__name__)`. When you have a named logger, e.g. `server.game`, the `server.` means that the server logger is the parent logger of `game`. By doing `getLogger()` (without input) in the main files, we are creating and configuring the `root` logger which all other loggers have as a parent by default.

This way we can use the `%(name)s` field to know the file the log message comes from.