### PR TITLE
Changed gameover mechanics in `Session`

### DIFF
--- a/server/game.py
+++ b/server/game.py
@@ -22,6 +22,8 @@ class Session:
         self.setting = setting
         self.actors = actors
 
+        self.gameover = False
+
         self.start_next_scene()
 
     @property
@@ -44,7 +46,7 @@ class Session:
         self.scene_started = False
 
     def is_gameover(self) -> bool:
-        return len(self.scene_stack) == 0 and self.current_scene is None
+        return self.gameover
 
     def play(self, user_input: str) -> Command:
         if self.is_gameover():
@@ -58,6 +60,7 @@ class Session:
                 resp = next(self.current_scene)
             except Exception as error:
                 logger.error("failed to get the next command from current scene. error: %s", error)
+                self.gameover = True
                 raise error
             self.scene_started = True
         else:
@@ -65,10 +68,15 @@ class Session:
                 resp = self.current_scene.send(user_input)
             except Exception as error:
                 logger.error("failed to get the next command from current scene. error: %s", error)
+                self.gameover = True
                 raise error
 
         if isinstance(resp, SceneEndCommand):
             self.start_next_scene()
+
+        if resp.is_game_over: 
+            logger.info("game has ended")
+            self.gameover = True
 
         self.last_scene_output = resp
         return resp


### PR DESCRIPTION
Made the commands aware and responsible for deciding when the game was over -- need to change Session to respect this command. Note this allows for short-circuiting of the game; any scene can end the game at any time with any command now.