### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+client
+__pycache__
+flask_session
+/server.log

--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
 #For local builds, create a 'env' file in the root directory and paste this here, adding in your keys.
-#'LLM_API_KEY' = <YOUR_API_KEY>
-#'SECRET_KEY' = <YOUR_FLASK_SECRET_KEY>
-#'FLASK_ENV' = <YOUR_FLASK_ENV>
+#LLM_API_KEY = <YOUR_API_KEY>
+#SECRET_KEY = <YOUR_FLASK_SECRET_KEY>
+#FLASK_ENV= <YOUR_FLASK_ENV>

--- a/README.md
+++ b/README.md
@@ -15,15 +15,17 @@ In Rattlesnake Ridge, the player faces off against 4 AI Agents (Powered by the O
 
 To get started with this project, follow these steps:
 
-1. Clone the repository:
+### 1. Clone the repository:
 
    ```bash
    git clone https://github.com/WilliamHCarter/RattlesnakeRidge.git
    cd RattlesnakeRidge
    ```
 
-2. Install dependencies:
+### 2. Install dependencies:
 
+  **Python**
+   
    Make sure you have Python installed. If not, you can download and install Python from [python.org](https://www.python.org/downloads/).
 
    It's recommended to use a virtual environment to keep your project dependencies isolated:
@@ -40,24 +42,20 @@ To get started with this project, follow these steps:
    source venv/bin/activate
    ```
 
-   Once the virtual environment is activated, you can install the dependencies using:
-
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-   Docker
+   **Docker**
+   
    This project is containerized using Docker. Make sure you have Docker installed. If not, you can download and install Docker from [Docker's official website.](https://www.docker.com/)
 
-   Node & NPM
+   **Node & NPM**
+   
    This project uses NPM for its frontend dependency installation. Make sure you have node installed. If not, you can download and install Node.js from [nodejs.org](https://nodejs.org/). npm is included with the Node.js installation.
 
-3. Add API Key:
+### 3. Add API Key:
 
    Create a file named `.env`, and paste the contents of `.env.template` into it.
    Then, add your key to the `LLM_API_KEY` variable inside your new `.env` file.
 
-4. Run Flask App:
+### 4. Run Flask App:
 
    Build the Docker image and run it as a container:
 
@@ -72,10 +70,11 @@ To get started with this project, follow these steps:
 
    The Flask app will be accessible at [http://localhost:5000](http://localhost:5000/).
 
-5. Run Frontend
+### 5. Run Frontend
 
-   Navigate to the `client` directory and run the commans:
-   ```npm install
+   Navigate to the `client` directory and run the commands:
+   ```
+   npm install
    npm run dev
    ```
    This will open up a new UI instance at [http://localhost:5173](http://localhost:5173/) which you can use to interact with the app.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
 In Rattlesnake Ridge, the player faces off against 4 AI Agents (Powered by the OpenAI API) in order to solve a mystery in a small western town. These AI agents are aware of some facts surrounding the case, and may provide clues to the player, or deceive the player, based on the scenario and their role in the crime that the player is investigating.
 
 ## Quick Start
+
 To get started with this project, follow these steps:
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/WilliamHCarter/RattlesnakeRidge.git
    cd RattlesnakeRidge
@@ -39,10 +41,41 @@ To get started with this project, follow these steps:
    ```
 
    Once the virtual environment is activated, you can install the dependencies using:
+
    ```bash
    pip install -r requirements.txt
    ```
+
+   Docker
+   This project is containerized using Docker. Make sure you have Docker installed. If not, you can download and install Docker from [Docker's official website.](https://www.docker.com/)
+
+   Node & NPM
+   This project uses NPM for its frontend dependency installation. Make sure you have node installed. If not, you can download and install Node.js from [nodejs.org](https://nodejs.org/). npm is included with the Node.js installation.
+
 3. Add API Key:
 
    Create a file named `.env`, and paste the contents of `.env.template` into it.
    Then, add your key to the `LLM_API_KEY` variable inside your new `.env` file.
+
+4. Run Flask App:
+
+   Build the Docker image and run it as a container:
+
+   ```bash
+   # Build the Docker image
+   docker build -t my-server .
+
+   # Run the Docker container
+   docker run -p 5000:5000 --env-file=.env my-server
+
+   ```
+
+   The Flask app will be accessible at [http://localhost:5000](http://localhost:5000/).
+
+5. Run Frontend
+
+   Navigate to the `client` directory and run the commans:
+   ```npm install
+   npm run dev
+   ```
+   This will open up a new UI instance at [http://localhost:5173](http://localhost:5173/) which you can use to interact with the app.

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,18 @@
+# Use an official Python runtime as a base image
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy the server directory contents into the container
+COPY /server ./server
+COPY requirements.txt .
+COPY run_server.py .
+# Install the requirements
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Expose the port the app runs on
+EXPOSE 5000
+
+# Run the application
+CMD ["python", "run_server.py"]

--- a/run_server.py
+++ b/run_server.py
@@ -20,4 +20,4 @@ logger.addHandler(fh)
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -24,7 +24,6 @@ else:
 
 CORS(app, origins=[origins])
 
-
 Session(app)
 
 from server import routes


### PR DESCRIPTION
Flask app can now be run as a docker container by following the updated readme instructions. Don't forget to update your `.env` file to no longer use strings and instead use raw text.